### PR TITLE
YACS Data Dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .git
 node_modules/
 node_modules/
+data/
 .vscode

--- a/api.js
+++ b/api.js
@@ -76,6 +76,12 @@ module.exports = {
 				if (!err) next(null, body);
 				else next(err);
 			});
+		},
+		courses: (dep_id, next) => {
+			request.get(sources.yacs.courses + dep_id + "&show_periods=true&show_sections=true&", (err, res, body) => {
+				if (!err) next(null, body);
+				else next(err);
+			});
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -1,15 +1,13 @@
-const request = require("request");
 const express = require("express");
-const cookieParser = require("cookie-parser");
 const path = require('path');
 const api = require('./api.js');
+const cron = require('node-cron');
+const runUpdate = require('./update_data.js');
 
 var app = express();
 
-app.use(cookieParser());
-
 // YACS
-require('./routes/yacs.js')(app, api.yacs);
+require('./routes/yacs.js')(app, api.yacs, runUpdate);
 
 // SIS
 require('./routes/sis.js')(app, api.sis);
@@ -24,4 +22,9 @@ app.get("/verify_status", (req, res) => {
 
 app.listen(8080, () => {
 	console.log("Listening on port 8080");
+});
+
+cron.schedule('0 0 * * *', () => {
+  console.log("Updating YACS data");
+  runUpdate();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2132,6 +2132,15 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "node-cron": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-2.0.3.tgz",
+      "integrity": "sha512-eJI+QitXlwcgiZwNNSRbqsjeZMp5shyajMR81RZCqeW0ZDEj4zU9tpd4nTh/1JsBiKbF8d08FCewiipDmVIYjg==",
+      "requires": {
+        "opencollective-postinstall": "^2.0.0",
+        "tz-offset": "0.0.1"
+      }
+    },
     "nodemon": {
       "version": "1.18.9",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.9.tgz",
@@ -2260,6 +2269,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "opencollective-postinstall": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -3007,6 +3021,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "tz-offset": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tz-offset/-/tz-offset-0.0.1.tgz",
+      "integrity": "sha512-kMBmblijHJXyOpKzgDhKx9INYU4u4E1RPMB0HqmKSgWG8vEcf3exEfLh4FFfzd3xdQOw9EuIy/cP0akY6rHopQ=="
     },
     "undefsafe": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon ."
+    "start": "nodemon --ignore 'data/**/*' ."
   },
   "author": "",
   "license": "ISC",
@@ -13,6 +13,7 @@
     "cheerio": "^1.0.0-rc.2",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
+    "node-cron": "^2.0.3",
     "nodemon": "^1.18.9",
     "puppeteer": "^1.11.0",
     "request": "^2.88.0",

--- a/routes/yacs.js
+++ b/routes/yacs.js
@@ -1,11 +1,8 @@
-module.exports = (app, api) => {
+module.exports = (app, api, update) => {
 
+	app.get("/api/update", (req,res) => {
+		update();
+		res.send("Ran update");
+	});
 
-	app.get("/api/departments", (req,res) => 
-		api.departments((err, body) => {
-			if (!err) res.send(body);
-			else res.send(err);
-		}));
-
-	
 }

--- a/sources.json
+++ b/sources.json
@@ -6,6 +6,7 @@
 		"get_student_menu": "https://sis.rpi.edu/rss/twbkwbis.P_GenMenu?name=bmenu.P_StuMainMnu"
 	},
 	"yacs": {
-		"departments": "https://yacs.cs.rpi.edu/api/v5/schools.json?show_departments=true"
+		"departments": "https://yacs.cs.rpi.edu/api/v5/schools.json?show_departments=true",
+		"courses": "https://yacs.cs.rpi.edu/api/v5/courses.json?department_id="
 	}
 }

--- a/update_data.js
+++ b/update_data.js
@@ -1,0 +1,38 @@
+const api = require('./api.js').yacs;
+const fs = require('fs');
+
+var num_files = 0;
+var total = 0;
+
+function writeDepartment (dep) {
+	api.courses(dep.id, (err, body) => {
+		if (err) console.log(err);
+		else
+			fs.writeFile("./data/courses/"+dep.id+".json", body, (err) => {
+		    if (err) return console.log(err);
+		    num_files++;
+		    console.log("\x1b[1A\x1b[0K- ["+num_files+"/"+total+"] Saved '"+dep.id+".json'");
+			});
+	})
+}
+
+module.exports = () => {
+	num_files = 0;
+	api.departments((err, body) => {
+		if (err) console.log(err);
+		else
+			fs.writeFile("./data/departments.json", body, (err2) => {
+		    if (err2)
+		        return console.log(err2);
+		    console.log("- Saved 'departments.json'");
+		    var obj = JSON.parse(body)
+		    total = 0;
+		    obj.schools.forEach((school) => total+=school.departments.length);
+				obj.schools.forEach(
+					(school) => school.departments.forEach((item) => {
+						writeDepartment(item)
+					})
+				);
+			});
+	});
+}


### PR DESCRIPTION
Uses a data dump cron-job approach in order to not overload YACS when people make requests through Schedj.

To test:
- Load server
- Send a `GET` request to `localhost:8080/api/update`
- Should return a success message
- In the console, observe the downloading indicator
- Check the `schedj-backend/data/` folder for collection of JSON files