### PR TITLE
Holds

### DIFF
--- a/api.js
+++ b/api.js
@@ -125,6 +125,16 @@ module.exports = {
 		},
 		get_grades: (term, next) => {
 			
+		},
+		get_holds_bool: (next) => {
+			request.get(sources.sis.holds, (err, res, html) => {
+				if (err) next(err);
+				else {
+					if ($('body > div.pagebodydiv > table.datadisplaytable > tbody > tr:nth-child(2) > td:nth-child(1)').html()!='')
+						next(null, true);
+					else next(null, false);
+				}
+			})
 		}
 	},
 

--- a/api.js
+++ b/api.js
@@ -15,6 +15,12 @@ var moment = require('moment');
 module.exports = {
 
 	sis: {
+		fetch: (url, next) => {
+			request.get("http://sis.rpi.edu/" + url, (err,res,body) => {
+				if (err) next(err);
+				else next(null, body);
+			});
+		},
 		login: (user, pass, next) => {
 			// gets the URL first to initialize the cookie
 			request.get(sources.sis.login, () =>{

--- a/routes/sis.js
+++ b/routes/sis.js
@@ -69,4 +69,11 @@ module.exports = function(app, api, auth) {
 	app.get("/student_info", (req, res) => {
 		
 	});
+
+	app.get("/exists_hold", (req, res) => {
+		api.get_holds_bool((err, hold_exists) => {
+			if (err) res.status(500).send(err);
+			else res.send(hold_exists);
+		});
+	})
 }

--- a/routes/sis.js
+++ b/routes/sis.js
@@ -1,6 +1,13 @@
 
 module.exports = function(app, api, auth) {
 
+	app.get("/fetch", (req,res) => {
+		api.fetch(req.query.url, (err,body) => {
+			if (err) res.status(500).send(err);
+			else res.send(body);
+		})
+	});
+
 	// The login route has a lot going on; this takes a few key bits of information from SIS at once
 	
 	app.post("/login", (req,res) =>

--- a/sources.json
+++ b/sources.json
@@ -5,7 +5,8 @@
 		"classes": "https://sis.rpi.edu/rss/bwskfreg.P_AltPin",
 		"get_student_menu": "https://sis.rpi.edu/rss/twbkwbis.P_GenMenu?name=bmenu.P_StuMainMnu",
 		"address": "https://sis.rpi.edu/rss/bwgkogad.P_SelectAtypUpdate",
-		"registration": "https://sis.rpi.edu/rss/bwskrsta.P_RegsStatusDisp"
+		"registration": "https://sis.rpi.edu/rss/bwskrsta.P_RegsStatusDisp",
+		"holds": "https://sis.rpi.edu/rss/bwskoacc.P_ViewHold"
 	},
 	"yacs": {
 		"departments": "https://yacs.cs.rpi.edu/api/v5/schools.json?show_departments=true",


### PR DESCRIPTION
Adds `/fetch?url=` for grabbing particular SIS pages with authentication. Also adds a boolean path `/exists_hold` that returns a value indicating if there is currently a hold on the user's account.

Test by sending requests to these two routes.